### PR TITLE
Refactor: Remove session replay plugin from AmplitudeProvider

### DIFF
--- a/@providers/AmplitudeProvider.tsx
+++ b/@providers/AmplitudeProvider.tsx
@@ -10,9 +10,6 @@ import {
     ReactNode
 } from "react"
 import { useAuth } from "@/context/auth"
-import { sessionReplayPlugin } from "@amplitude/plugin-session-replay-browser"
-
-const sessionReplayTracking = sessionReplayPlugin()
 
 interface AmplitudeContextType {
     amplitude: typeof amplitude
@@ -36,7 +33,6 @@ export function AmplitudeProvider({ children }: { children: ReactNode }) {
             return
         }
 
-        amplitude.add(sessionReplayTracking)
         amplitude.init(
             process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY ||
             "959de43582eb3458ab34b08a446e036c"


### PR DESCRIPTION
- Removed the import and usage of `sessionReplayPlugin` from `@amplitude/plugin-session-replay-browser`.
- Updated `AmplitudeProvider` to no longer add the session replay tracking to the Amplitude instance.